### PR TITLE
Analysis of Systematics variations

### DIFF
--- a/ComputeSystematicsCF.py
+++ b/ComputeSystematicsCF.py
@@ -1,0 +1,219 @@
+'''
+Script to compute the raw correlation function.
+The output file is RawCF_suffix.root
+
+Usage:
+python3 ComputeRawCF.py cfg.yml
+
+'''
+import os
+import argparse
+import yaml
+
+from ROOT import TFile, TH2F, TH1D
+
+from fempy import logger as log
+from fempy.utils.io import Load, GetKeyNames
+
+parser = argparse.ArgumentParser()
+parser.add_argument('cfg', default='')
+parser.add_argument('--debug', default=False, action='store_true')
+args = parser.parse_args()
+
+if args.debug:
+    log.setLevel(1)
+
+# Load yaml file
+with open(args.cfg, "r") as stream:
+    try:
+        cfg = yaml.safe_load(stream)
+    except yaml.YAMLError as exc:
+        log.critical('Yaml configuration could not be loaded. Is it properly formatted?')
+
+regions = ['CFsystvar']
+
+# Load input files with same- and mixed-event distributions
+inFiles = []
+suffixes = []
+for iSystFile, iSystVar in zip(cfg['infile'], cfg['suffixes']):
+    inFiles.append(TFile(iSystFile))
+    suffixes.append(TFile(iSystVar))
+
+# Define the output file
+oFileBaseName = 'SystCFs'
+if cfg['suffix'] != '' and cfg['suffix'] is not None:
+    oFileBaseName += f'_{cfg["suffix"]}'
+oFileName = os.path.join(cfg['odir'], oFileBaseName + '.root')
+
+# Open the output file
+try:
+    oFile = TFile.Open(oFileName, 'recreate')
+except OSError:
+    log.critical('The output file %s is not writable', oFileName)
+combs = ['p02', 'p03', 'p12', 'p13']
+for comb in combs:
+    oFile.mkdir(comb)
+
+# list of histograms each containing the CF entries for
+# all variations for a specific bin 
+hCFBinEntries = []
+for iBin in range(cfg['systevalnbins']):
+    hCFBinEntries.append(TH1D(f"h{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV", 
+                              f"h{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV", 
+                              cfg['systhistobins'], cfg['systhistolowedge'], 
+                              cfg['systhistouppedge']))
+
+# Compute the correlation functions for all systematic variations
+hSE = {}
+hME = {}
+hMErew = {}
+for iSystFile, iSystVar in zip(inFiles, suffixes):
+    for comb in combs:
+        iPart1 = int(comb[1])
+        iPart2 = int(comb[2])
+        oFile.cd(comb)
+
+        hSE[comb] = {}
+        hME[comb] = {}
+        hMErew[comb] = {}
+        for region in regions:
+            if f'HMResults{iSystVar}' in GetKeyNames(iSystFile): # Make correlation functions from FemtoDream
+                fdcomb = f'Particle{iPart1}_Particle{iPart2}'
+                # The histograms are casted to TH1D with TH1::Copy to avoid NotImplementedError when computing hSE/hME
+                hSE[comb][region] = TH1D()
+                Load(iSystFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/SEDist_{fdcomb}').Copy(hSE[comb][region])
+
+                # The histograms are casted to TH1D with TH1::Copy to avoid NotImplementedError when computing hSE/hME
+                hME[comb][region] = TH1D()
+                Load(iSystFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/MEDist_{fdcomb}').Copy(hME[comb][region])
+
+                # No need to cast the these because the projection of TH2D and TH2F is always TH1D
+                hSEmultk = Load(iSystFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/SEMultDist_{fdcomb}')
+                hMEmultk = Load(iSystFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/MEMultDist_{fdcomb}')
+
+            nbins = hMEmultk.ProjectionX().GetNbinsX()
+            hMEreweightk = TH1D("MErewdistr", "MErewdistr", nbins, hMEmultk.GetXaxis().GetXmin(), hMEmultk.GetXaxis().GetXmax())
+            for iBin in range(hMEmultk.ProjectionY().GetNbinsX() + 2): # Loop over underflow, all bins, and overflow
+                hSEbinmult = hSEmultk.ProjectionX(f'{comb}SEdistr', iBin, iBin)
+                hMEbinmult = hMEmultk.ProjectionX(f'{comb}MEdistr', iBin, iBin)
+                if(hMEbinmult.Integral() > 0):
+                    hMEreweightk.Add(hMEbinmult, hSEbinmult.Integral()/hMEbinmult.Integral())
+            hMErew[comb][region] = hMEreweightk
+
+    # Sum pair and antipair
+    for comb in combs:
+        hSE['p02_13'] = {}
+        hSE['p03_12'] = {}
+        hME['p02_13'] = {}
+        hME['p03_12'] = {}
+        hMErew['p02_13'] = {}
+        hMErew['p03_12'] = {}
+
+        for region in regions:
+            hSE['p02_13'][region] = hSE['p02'][region] + hSE['p13'][region]
+            hME['p02_13'][region] = hME['p02'][region] + hME['p13'][region]
+            hMErew['p02_13'][region] = hMErew['p02'][region] + hMErew['p13'][region]
+
+            hSE['p03_12'][region] = hSE['p03'][region] + hSE['p12'][region]
+            hME['p03_12'][region] = hME['p03'][region] + hME['p12'][region]
+            hMErew['p03_12'][region] = hMErew['p03'][region] + hMErew['p12'][region]
+
+    # Compute the CF and write to file
+    for comb in combs + ['p02_13', 'p03_12']:
+        for region in regions:
+            rebin = round(float(cfg['binwidth']) / (hSE[comb][region].GetBinWidth(1) * 1000))
+            hSE[comb][region].Rebin(rebin)
+            hME[comb][region].Rebin(rebin)
+            hMErew[comb][region].Rebin(rebin)
+
+            if cfg['norm'] is None:  # if not specified, normalize to the yields
+                norm = hME[comb][region].GetEntries() / hSE[comb][region].GetEntries()
+                normrew = hMErew[comb][region].GetEntries() / hSE[comb][region].GetEntries()
+            else:
+                log.critical('Normalization method not implemented')
+
+            hSE[comb][region].Sumw2()
+            hME[comb][region].Sumw2() # Just to trigger the same draw option as for hSE
+
+            hCF = norm * hSE[comb][region] / hME[comb][region]
+            hCFrew = normrew * hSE[comb][region] / hMErew[comb][region]
+
+            oFile.mkdir(f'{comb}/{region}/{iSystVar}')
+            oFile.cd(f'{comb}/{region}/{iSystVar}')
+
+            hSE[comb][region].SetName(f'hSE_{iSystVar}')
+            hSE[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
+            hSE[comb][region].Write()
+
+            hME[comb][region].SetName(f'hME_{iSystVar}')
+            hME[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
+            hME[comb][region].Write()
+
+            hMErew[comb][region].SetName(f'hMErew_{iSystVar}')
+            hMErew[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
+
+            hCF.SetName(f'hCF_{iSystVar}')
+            hCF.SetTitle(';#it{k}* (GeV/#it{c});#it{C}(#it{k}*)')
+            hCF.Write()
+
+            hCFrew.SetName(f'hCFrew_{iSystVar}')
+            hCFrew.SetTitle(';#it{k}* (GeV/#it{c});#it{C}(#it{k}*)')
+            hCFrew.Write()
+
+            for iBin in range(cfg['systevalrange']):
+                hCFBinEntries[iBin].Fill(hCFrew.GetBinContent(iBin+1))
+            
+            print(f'Finished systematic variation n° {iSystVar}')
+
+hCFselected = TH1D() Load(TFile(cfg['infileCF']), cfg['infileCFpath'])
+
+oFile.cd()
+oFile.mkdir('binsfits')
+hCFYields = TH1D("hCFYields", "hCFYields", cfg['systevalnbins'], 
+                 cfg['systevalnbins'][0]*cfg['binwidth'], 
+                 cfg['systevalnbins'][1]*cfg['binwidth'])
+hCFmeans = TH1D("hCFmeans", "hCFmeans", cfg['systevalnbins'], 
+                 cfg['systevalnbins'][0]*cfg['binwidth'], 
+                 cfg['systevalnbins'][1]*cfg['binwidth'])
+hSystUnc = TH1D("hSystUnc", "hSystUnc", cfg['systevalnbins'], 
+                 cfg['systevalnbins'][0]*cfg['binwidth'], 
+                 cfg['systevalnbins'][1]*cfg['binwidth'])
+hRelSystUnc = TH1D("hRelSystUnc", "hRelSystUnc", cfg['systevalnbins'], 
+                 cfg['systevalnbins'][0]*cfg['binwidth'], 
+                 cfg['systevalnbins'][1]*cfg['binwidth'])
+hRelStatUnc = TH1D("hRelStatUnc", "hRelStatUnc", cfg['systevalnbins'], 
+                   cfg['systevalnbins'][0]*cfg['binwidth'], 
+                   cfg['systevalnbins'][1]*cfg['binwidth'])
+hRatioStatSystUnc = TH1D("hRatioStatSystUnc", "hRatioStatSystUnc", cfg['systevalnbins'], 
+                         cfg['systevalnbins'][0]*cfg['binwidth'], 
+                         cfg['systevalnbins'][1]*cfg['binwidth'])
+hCFWithStatSystUnc = TH1D("hCFWithStatSystUnc", "hCFWithStatSystUnc", cfg['systevalnbins'], 
+                          cfg['systevalnbins'][0]*cfg['binwidth'], 
+                          cfg['systevalnbins'][1]*cfg['binwidth'])
+for iBin, ihCFbin in enumerate(hCFBinEntries):
+    oFile.cd('binsfits')
+    ihCFbin.Fit("gaus")
+    ihCFbin.Write(f"hCFbin{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV")
+    gausFit = ihCFbin.GetListOfFunctions().FindObject("gaus")
+    hCFYields.SetBinContent(iBin+1, gausFit.GetParameter(0))
+    hCFMeans.SetBinContent(iBin+1, gausFit.GetParameter(1))
+    hSystUnc.SetBinContent(iBin+1, gausFit.GetParameter(2))
+    hRelSystUnc.SetBinContent(iBin+1, hSystUnc.GetBinContent(iBin+1)/hCFselected.GetBinContent(iBin+1))
+    hRelStatUnc.SetBinContent(iBin+1, hCFselected.GetBinError(iBin+1)/hCFselected.GetBinContent(iBin+1))
+    hRelStatUnc.SetBinContent(iBin+1, hCFselected.GetBinError(iBin+1)/hSystUnc.GetBinContent(iBin+1))
+    hCFWithStatSystUnc.SetBinContent(iBin+1, hCFselected.GetBinContent(iBin+1))
+    hCFWithStatSystUnc.SetBinError(iBin+1, np.sqrt(hCFselected.GetBinError(iBin+1)**2 + 
+                                                   hSystUnc.GetBinContent(iBin+1)**2 ) )
+    
+oFile.mkdir('systunc')
+oFile.cd('systunc')    
+hCFYields.Write()
+hCFMeans.Write()
+hSystUnc.Write()
+hRelSystUnc.Write()
+hRelStatUnc.Write()
+hRelStatUnc.Write()
+hCFWithStatSystUnc.Write()
+
+oFile.Close()
+print(f'output saved in {oFileName}')

--- a/ComputeSystematicsCF.py
+++ b/ComputeSystematicsCF.py
@@ -32,13 +32,6 @@ with open(args.cfg, "r") as stream:
 
 regions = ['CFsystvar']
 
-# Load input files with same- and mixed-event distributions
-inFiles = []
-suffixes = []
-for iSystFile, iSystVar in zip(cfg['infile'], cfg['suffixes']):
-    inFiles.append(TFile(iSystFile))
-    suffixes.append(TFile(iSystVar))
-
 # Define the output file
 oFileBaseName = 'SystCFs'
 if cfg['suffix'] != '' and cfg['suffix'] is not None:
@@ -67,153 +60,160 @@ for iBin in range(cfg['systevalnbins']):
 hSE = {}
 hME = {}
 hMErew = {}
-for iSystFile, iSystVar in zip(inFiles, suffixes):
-    for comb in combs:
-        iPart1 = int(comb[1])
-        iPart2 = int(comb[2])
-        oFile.cd(comb)
+for iSystFile, systFileName in enumerate(cfg['infilessyst']):
+    print(f'Picking file {iSystFile}')
+    systFile = TFile(systFileName)
+    for iSystVar in cfg['suffixessyst'][iSystFile]:
+        print(f'runsuffix {iSystVar}')
+        for comb in combs:
+            iPart1 = int(comb[1])
+            iPart2 = int(comb[2])
+            oFile.cd(comb)
 
-        hSE[comb] = {}
-        hME[comb] = {}
-        hMErew[comb] = {}
-        for region in regions:
-            if f'HMResults{iSystVar}' in GetKeyNames(iSystFile): # Make correlation functions from FemtoDream
-                fdcomb = f'Particle{iPart1}_Particle{iPart2}'
-                # The histograms are casted to TH1D with TH1::Copy to avoid NotImplementedError when computing hSE/hME
-                hSE[comb][region] = TH1D()
-                Load(iSystFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/SEDist_{fdcomb}').Copy(hSE[comb][region])
+            hSE[comb] = {}
+            hME[comb] = {}
+            hMErew[comb] = {}
+            for region in regions:
+                if f'HMResults{iSystVar}' in GetKeyNames(systFile): # Make correlation functions from FemtoDream
+                    fdcomb = f'Particle{iPart1}_Particle{iPart2}'
+                    # The histograms are casted to TH1D with TH1::Copy to avoid NotImplementedError when computing hSE/hME
+                    hSE[comb][region] = TH1D()
+                    Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/SEDist_{fdcomb}').Copy(hSE[comb][region])
 
-                # The histograms are casted to TH1D with TH1::Copy to avoid NotImplementedError when computing hSE/hME
-                hME[comb][region] = TH1D()
-                Load(iSystFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/MEDist_{fdcomb}').Copy(hME[comb][region])
+                    # The histograms are casted to TH1D with TH1::Copy to avoid NotImplementedError when computing hSE/hME
+                    hME[comb][region] = TH1D()
+                    Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/MEDist_{fdcomb}').Copy(hME[comb][region])
 
-                # No need to cast the these because the projection of TH2D and TH2F is always TH1D
-                hSEmultk = Load(iSystFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/SEMultDist_{fdcomb}')
-                hMEmultk = Load(iSystFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/MEMultDist_{fdcomb}')
+                    # No need to cast the these because the projection of TH2D and TH2F is always TH1D
+                    hSEmultk = Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/SEMultDist_{fdcomb}')
+                    hMEmultk = Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/MEMultDist_{fdcomb}')
 
-            nbins = hMEmultk.ProjectionX().GetNbinsX()
-            hMEreweightk = TH1D("MErewdistr", "MErewdistr", nbins, hMEmultk.GetXaxis().GetXmin(), hMEmultk.GetXaxis().GetXmax())
-            for iBin in range(hMEmultk.ProjectionY().GetNbinsX() + 2): # Loop over underflow, all bins, and overflow
-                hSEbinmult = hSEmultk.ProjectionX(f'{comb}SEdistr', iBin, iBin)
-                hMEbinmult = hMEmultk.ProjectionX(f'{comb}MEdistr', iBin, iBin)
-                if(hMEbinmult.Integral() > 0):
-                    hMEreweightk.Add(hMEbinmult, hSEbinmult.Integral()/hMEbinmult.Integral())
-            hMErew[comb][region] = hMEreweightk
+                nbins = hMEmultk.ProjectionX().GetNbinsX()
+                hMEreweightk = TH1D("MErewdistr", "MErewdistr", nbins, hMEmultk.GetXaxis().GetXmin(), hMEmultk.GetXaxis().GetXmax())
+                for iBin in range(hMEmultk.ProjectionY().GetNbinsX() + 2): # Loop over underflow, all bins, and overflow
+                    hSEbinmult = hSEmultk.ProjectionX(f'{comb}SEdistr', iBin, iBin)
+                    hMEbinmult = hMEmultk.ProjectionX(f'{comb}MEdistr', iBin, iBin)
+                    if(hMEbinmult.Integral() > 0):
+                        hMEreweightk.Add(hMEbinmult, hSEbinmult.Integral()/hMEbinmult.Integral())
+                hMErew[comb][region] = hMEreweightk
 
-    # Sum pair and antipair
-    for comb in combs:
-        hSE['p02_13'] = {}
-        hSE['p03_12'] = {}
-        hME['p02_13'] = {}
-        hME['p03_12'] = {}
-        hMErew['p02_13'] = {}
-        hMErew['p03_12'] = {}
+        # Sum pair and antipair
+        for comb in combs:
+            hSE['p02_13'] = {}
+            hSE['p03_12'] = {}
+            hME['p02_13'] = {}
+            hME['p03_12'] = {}
+            hMErew['p02_13'] = {}
+            hMErew['p03_12'] = {}
 
-        for region in regions:
-            hSE['p02_13'][region] = hSE['p02'][region] + hSE['p13'][region]
-            hME['p02_13'][region] = hME['p02'][region] + hME['p13'][region]
-            hMErew['p02_13'][region] = hMErew['p02'][region] + hMErew['p13'][region]
+            for region in regions:
+                hSE['p02_13'][region] = hSE['p02'][region] + hSE['p13'][region]
+                hME['p02_13'][region] = hME['p02'][region] + hME['p13'][region]
+                hMErew['p02_13'][region] = hMErew['p02'][region] + hMErew['p13'][region]
 
-            hSE['p03_12'][region] = hSE['p03'][region] + hSE['p12'][region]
-            hME['p03_12'][region] = hME['p03'][region] + hME['p12'][region]
-            hMErew['p03_12'][region] = hMErew['p03'][region] + hMErew['p12'][region]
+                hSE['p03_12'][region] = hSE['p03'][region] + hSE['p12'][region]
+                hME['p03_12'][region] = hME['p03'][region] + hME['p12'][region]
+                hMErew['p03_12'][region] = hMErew['p03'][region] + hMErew['p12'][region]
 
-    # Compute the CF and write to file
-    for comb in combs + ['p02_13', 'p03_12']:
-        for region in regions:
-            rebin = round(float(cfg['binwidth']) / (hSE[comb][region].GetBinWidth(1) * 1000))
-            hSE[comb][region].Rebin(rebin)
-            hME[comb][region].Rebin(rebin)
-            hMErew[comb][region].Rebin(rebin)
+        # Compute the CF and write to file
+        for comb in combs + ['p02_13', 'p03_12']:
+            for region in regions:
+                rebin = round(float(cfg['binwidth']) / (hSE[comb][region].GetBinWidth(1) * 1000))
+                hSE[comb][region].Rebin(rebin)
+                hME[comb][region].Rebin(rebin)
+                hMErew[comb][region].Rebin(rebin)
 
-            if cfg['norm'] is None:  # if not specified, normalize to the yields
-                norm = hME[comb][region].GetEntries() / hSE[comb][region].GetEntries()
-                normrew = hMErew[comb][region].GetEntries() / hSE[comb][region].GetEntries()
-            else:
-                log.critical('Normalization method not implemented')
+                if cfg['norm'] is None:  # if not specified, normalize to the yields
+                    norm = hME[comb][region].GetEntries() / hSE[comb][region].GetEntries()
+                    normrew = hMErew[comb][region].GetEntries() / hSE[comb][region].GetEntries()
+                else:
+                    firstBin = hSE[comb][region].FindBin(cfg['norm'][0]*1.0001)
+                    lastBin = hSE[comb][region].FindBin(cfg['norm'][1]*0.9999)
+                    norm = hME[comb][region].Integral(firstBin, lastBin) / hSE[comb][region].Integral(firstBin, lastBin)
+                    normrew = hMErew[comb][region].Integral(firstBin, lastBin) / hSE[comb][region].Integral(firstBin, lastBin)
 
-            hSE[comb][region].Sumw2()
-            hME[comb][region].Sumw2() # Just to trigger the same draw option as for hSE
+                hSE[comb][region].Sumw2()
+                hME[comb][region].Sumw2() # Just to trigger the same draw option as for hSE
 
-            hCF = norm * hSE[comb][region] / hME[comb][region]
-            hCFrew = normrew * hSE[comb][region] / hMErew[comb][region]
+                hCF = norm * hSE[comb][region] / hME[comb][region]
+                hCFrew = normrew * hSE[comb][region] / hMErew[comb][region]
 
-            oFile.mkdir(f'{comb}/{region}/{iSystVar}')
-            oFile.cd(f'{comb}/{region}/{iSystVar}')
+                oFile.mkdir(f'{comb}/{region}/{iSystVar}')
+                oFile.cd(f'{comb}/{region}/{iSystVar}')
 
-            hSE[comb][region].SetName(f'hSE_{iSystVar}')
-            hSE[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
-            hSE[comb][region].Write()
+                hSE[comb][region].SetName(f'hSE_{iSystVar}')
+                hSE[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
+                hSE[comb][region].Write()
 
-            hME[comb][region].SetName(f'hME_{iSystVar}')
-            hME[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
-            hME[comb][region].Write()
+                hME[comb][region].SetName(f'hME_{iSystVar}')
+                hME[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
+                hME[comb][region].Write()
 
-            hMErew[comb][region].SetName(f'hMErew_{iSystVar}')
-            hMErew[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
+                hMErew[comb][region].SetName(f'hMErew_{iSystVar}')
+                hMErew[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
 
-            hCF.SetName(f'hCF_{iSystVar}')
-            hCF.SetTitle(';#it{k}* (GeV/#it{c});#it{C}(#it{k}*)')
-            hCF.Write()
+                hCF.SetName(f'hCF_{iSystVar}')
+                hCF.SetTitle(';#it{k}* (GeV/#it{c});#it{C}(#it{k}*)')
+                hCF.Write()
 
-            hCFrew.SetName(f'hCFrew_{iSystVar}')
-            hCFrew.SetTitle(';#it{k}* (GeV/#it{c});#it{C}(#it{k}*)')
-            hCFrew.Write()
+                hCFrew.SetName(f'hCFrew_{iSystVar}')
+                hCFrew.SetTitle(';#it{k}* (GeV/#it{c});#it{C}(#it{k}*)')
+                hCFrew.Write()
 
-            for iBin in range(cfg['systevalrange']):
-                hCFBinEntries[iBin].Fill(hCFrew.GetBinContent(iBin+1))
-            
-            print(f'Finished systematic variation n° {iSystVar}')
+                for iBin in range(cfg['systevalnbins']):
+                    hCFBinEntries[iBin].Fill(hCFrew.GetBinContent(iBin+1))
 
-hCFselected = TH1D() Load(TFile(cfg['infileCF']), cfg['infileCFpath'])
+                print(f'Finished systematic variation n° {iSystVar}')
 
-oFile.cd()
-oFile.mkdir('binsfits')
-hCFYields = TH1D("hCFYields", "hCFYields", cfg['systevalnbins'], 
-                 cfg['systevalnbins'][0]*cfg['binwidth'], 
-                 cfg['systevalnbins'][1]*cfg['binwidth'])
-hCFmeans = TH1D("hCFmeans", "hCFmeans", cfg['systevalnbins'], 
-                 cfg['systevalnbins'][0]*cfg['binwidth'], 
-                 cfg['systevalnbins'][1]*cfg['binwidth'])
-hSystUnc = TH1D("hSystUnc", "hSystUnc", cfg['systevalnbins'], 
-                 cfg['systevalnbins'][0]*cfg['binwidth'], 
-                 cfg['systevalnbins'][1]*cfg['binwidth'])
-hRelSystUnc = TH1D("hRelSystUnc", "hRelSystUnc", cfg['systevalnbins'], 
-                 cfg['systevalnbins'][0]*cfg['binwidth'], 
-                 cfg['systevalnbins'][1]*cfg['binwidth'])
-hRelStatUnc = TH1D("hRelStatUnc", "hRelStatUnc", cfg['systevalnbins'], 
-                   cfg['systevalnbins'][0]*cfg['binwidth'], 
-                   cfg['systevalnbins'][1]*cfg['binwidth'])
-hRatioStatSystUnc = TH1D("hRatioStatSystUnc", "hRatioStatSystUnc", cfg['systevalnbins'], 
-                         cfg['systevalnbins'][0]*cfg['binwidth'], 
-                         cfg['systevalnbins'][1]*cfg['binwidth'])
-hCFWithStatSystUnc = TH1D("hCFWithStatSystUnc", "hCFWithStatSystUnc", cfg['systevalnbins'], 
-                          cfg['systevalnbins'][0]*cfg['binwidth'], 
-                          cfg['systevalnbins'][1]*cfg['binwidth'])
-for iBin, ihCFbin in enumerate(hCFBinEntries):
-    oFile.cd('binsfits')
-    ihCFbin.Fit("gaus")
-    ihCFbin.Write(f"hCFbin{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV")
-    gausFit = ihCFbin.GetListOfFunctions().FindObject("gaus")
-    hCFYields.SetBinContent(iBin+1, gausFit.GetParameter(0))
-    hCFMeans.SetBinContent(iBin+1, gausFit.GetParameter(1))
-    hSystUnc.SetBinContent(iBin+1, gausFit.GetParameter(2))
-    hRelSystUnc.SetBinContent(iBin+1, hSystUnc.GetBinContent(iBin+1)/hCFselected.GetBinContent(iBin+1))
-    hRelStatUnc.SetBinContent(iBin+1, hCFselected.GetBinError(iBin+1)/hCFselected.GetBinContent(iBin+1))
-    hRelStatUnc.SetBinContent(iBin+1, hCFselected.GetBinError(iBin+1)/hSystUnc.GetBinContent(iBin+1))
-    hCFWithStatSystUnc.SetBinContent(iBin+1, hCFselected.GetBinContent(iBin+1))
-    hCFWithStatSystUnc.SetBinError(iBin+1, np.sqrt(hCFselected.GetBinError(iBin+1)**2 + 
-                                                   hSystUnc.GetBinContent(iBin+1)**2 ) )
-    
-oFile.mkdir('systunc')
-oFile.cd('systunc')    
-hCFYields.Write()
-hCFMeans.Write()
-hSystUnc.Write()
-hRelSystUnc.Write()
-hRelStatUnc.Write()
-hRelStatUnc.Write()
-hCFWithStatSystUnc.Write()
-
+#hCFselected = TH1D() Load(TFile(cfg['infileCF']), cfg['infileCFpath'])
+#
+#oFile.cd()
+#oFile.mkdir('binsfits')
+#hCFYields = TH1D("hCFYields", "hCFYields", cfg['systevalnbins'], 
+#                 cfg['systevalnbins'][0]*cfg['binwidth'], 
+#                 cfg['systevalnbins'][1]*cfg['binwidth'])
+#hCFmeans = TH1D("hCFmeans", "hCFmeans", cfg['systevalnbins'], 
+#                 cfg['systevalnbins'][0]*cfg['binwidth'], 
+#                 cfg['systevalnbins'][1]*cfg['binwidth'])
+#hSystUnc = TH1D("hSystUnc", "hSystUnc", cfg['systevalnbins'], 
+#                 cfg['systevalnbins'][0]*cfg['binwidth'], 
+#                 cfg['systevalnbins'][1]*cfg['binwidth'])
+#hRelSystUnc = TH1D("hRelSystUnc", "hRelSystUnc", cfg['systevalnbins'], 
+#                 cfg['systevalnbins'][0]*cfg['binwidth'], 
+#                 cfg['systevalnbins'][1]*cfg['binwidth'])
+#hRelStatUnc = TH1D("hRelStatUnc", "hRelStatUnc", cfg['systevalnbins'], 
+#                   cfg['systevalnbins'][0]*cfg['binwidth'], 
+#                   cfg['systevalnbins'][1]*cfg['binwidth'])
+#hRatioStatSystUnc = TH1D("hRatioStatSystUnc", "hRatioStatSystUnc", cfg['systevalnbins'], 
+#                         cfg['systevalnbins'][0]*cfg['binwidth'], 
+#                         cfg['systevalnbins'][1]*cfg['binwidth'])
+#hCFWithStatSystUnc = TH1D("hCFWithStatSystUnc", "hCFWithStatSystUnc", cfg['systevalnbins'], 
+#                          cfg['systevalnbins'][0]*cfg['binwidth'], 
+#                          cfg['systevalnbins'][1]*cfg['binwidth'])
+#for iBin, ihCFbin in enumerate(hCFBinEntries):
+#    oFile.cd('binsfits')
+#    ihCFbin.Fit("gaus")
+#    ihCFbin.Write(f"hCFbin{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV")
+#    gausFit = ihCFbin.GetListOfFunctions().FindObject("gaus")
+#    hCFYields.SetBinContent(iBin+1, gausFit.GetParameter(0))
+#    hCFMeans.SetBinContent(iBin+1, gausFit.GetParameter(1))
+#    hSystUnc.SetBinContent(iBin+1, gausFit.GetParameter(2))
+#    hRelSystUnc.SetBinContent(iBin+1, hSystUnc.GetBinContent(iBin+1)/hCFselected.GetBinContent(iBin+1))
+#    hRelStatUnc.SetBinContent(iBin+1, hCFselected.GetBinError(iBin+1)/hCFselected.GetBinContent(iBin+1))
+#    hRelStatUnc.SetBinContent(iBin+1, hCFselected.GetBinError(iBin+1)/hSystUnc.GetBinContent(iBin+1))
+#    hCFWithStatSystUnc.SetBinContent(iBin+1, hCFselected.GetBinContent(iBin+1))
+#    hCFWithStatSystUnc.SetBinError(iBin+1, np.sqrt(hCFselected.GetBinError(iBin+1)**2 + 
+#                                                   hSystUnc.GetBinContent(iBin+1)**2 ) )
+#    
+#oFile.mkdir('systunc')
+#oFile.cd('systunc')    
+#hCFYields.Write()
+#hCFMeans.Write()
+#hSystUnc.Write()
+#hRelSystUnc.Write()
+#hRelStatUnc.Write()
+#hRelStatUnc.Write()
+#hCFWithStatSystUnc.Write()
+#
 oFile.Close()
 print(f'output saved in {oFileName}')

--- a/ComputeSystematicsCF.py
+++ b/ComputeSystematicsCF.py
@@ -1,16 +1,17 @@
 '''
 Script to compute the raw correlation function.
-The output file is RawCF_suffix.root
+The output file is RawSystCF_suffix.root
 
 Usage:
-python3 ComputeRawCF.py cfg.yml
+python3 ComputeSystematicsCF.py cfg.yml
 
 '''
 import os
 import argparse
 import yaml
+from itertools import chain
 
-from ROOT import TFile, TH2F, TH1D
+from ROOT import TFile, TH2F, TH1D, TH2D
 
 from fempy import logger as log
 from fempy.utils.io import Load, GetKeyNames
@@ -30,8 +31,6 @@ with open(args.cfg, "r") as stream:
     except yaml.YAMLError as exc:
         log.critical('Yaml configuration could not be loaded. Is it properly formatted?')
 
-regions = ['CFsystvar']
-
 # Define the output file
 oFileBaseName = 'RawSystCF'
 if cfg['suffix'] != '' and cfg['suffix'] is not None:
@@ -47,111 +46,111 @@ combs = ['p02', 'p03', 'p12', 'p13']
 for comb in combs:
     oFile.mkdir(comb)
 
+totalSystVars = len(list(chain.from_iterable(cfg['suffixessyst'])))
+hFemtoPairs = TH2D("hFemtoPairs", "Pairs in femto region", totalSystVars, 0, totalSystVars, len(combs), 0, len(combs))
+hFemtoPairs.SetStats(0)
+hFemtoPairs.GetYaxis().SetLabelSize(50)
+hFemtoPairs.GetXaxis().SetLabelSize(30)
+hFemtoPairs.GetXaxis().CenterLabels()
+
 # Compute the correlation functions for all systematic variations
 hSE = {}
 hME = {}
 hMErew = {}
 for iSystFile, systFileName in enumerate(cfg['infilessyst']):
-    print(f'Picking file {iSystFile}')
     systFile = TFile(systFileName)
     for iSystVar in cfg['suffixessyst'][iSystFile]:
-        print(f'runsuffix {iSystVar}')
-        for comb in combs:
+        for iComb, comb in enumerate(combs):
             iPart1 = int(comb[1])
             iPart2 = int(comb[2])
             oFile.cd(comb)
 
-            hSE[comb] = {}
-            hME[comb] = {}
-            hMErew[comb] = {}
-            for region in regions:
-                if f'HMResults{iSystVar}' in GetKeyNames(systFile): # Make correlation functions from FemtoDream
-                    fdcomb = f'Particle{iPart1}_Particle{iPart2}'
-                    # The histograms are casted to TH1D with TH1::Copy to avoid NotImplementedError when computing hSE/hME
-                    hSE[comb][region] = TH1D()
-                    Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/SEDist_{fdcomb}').Copy(hSE[comb][region])
+            if f'HMResults{iSystVar}' in GetKeyNames(systFile): # Make correlation functions from FemtoDream
+                fdcomb = f'Particle{iPart1}_Particle{iPart2}'
+                # The histograms are casted to TH1D with TH1::Copy to avoid NotImplementedError when computing hSE/hME
+                hSE[comb] = TH1D()
+                Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/SEDist_{fdcomb}').Copy(hSE[comb])
 
-                    # The histograms are casted to TH1D with TH1::Copy to avoid NotImplementedError when computing hSE/hME
-                    hME[comb][region] = TH1D()
-                    Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/MEDist_{fdcomb}').Copy(hME[comb][region])
 
-                    # No need to cast the these because the projection of TH2D and TH2F is always TH1D
-                    hSEmultk = Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/SEMultDist_{fdcomb}')
-                    hMEmultk = Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/MEMultDist_{fdcomb}')
+                hFemtoPairs.Fill(iSystVar-0.5, len(combs)-iComb-0.5, 
+                                 hSE[comb].Integral(hSE[comb].FindBin(0.0001), hSE[comb].FindBin(0.2*0.9999)))
+                hFemtoPairs.GetYaxis().SetBinLabel(len(combs)-iComb, comb)
+                hFemtoPairs.GetXaxis().SetBinLabel(iSystVar, str(iSystVar))
 
-                nbins = hMEmultk.ProjectionX().GetNbinsX()
-                hMEreweightk = TH1D("MErewdistr", "MErewdistr", nbins, hMEmultk.GetXaxis().GetXmin(), hMEmultk.GetXaxis().GetXmax())
-                for iBin in range(hMEmultk.ProjectionY().GetNbinsX() + 2): # Loop over underflow, all bins, and overflow
-                    hSEbinmult = hSEmultk.ProjectionX(f'{comb}SEdistr', iBin, iBin)
-                    hMEbinmult = hMEmultk.ProjectionX(f'{comb}MEdistr', iBin, iBin)
-                    if(hMEbinmult.Integral() > 0):
-                        hMEreweightk.Add(hMEbinmult, hSEbinmult.Integral()/hMEbinmult.Integral())
-                hMErew[comb][region] = hMEreweightk
+                # The histograms are casted to TH1D with TH1::Copy to avoid NotImplementedError when computing hSE/hME
+                hME[comb] = TH1D()
+                Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/MEDist_{fdcomb}').Copy(hME[comb])
+
+                # No need to cast the these because the projection of TH2D and TH2F is always TH1D
+                hSEmultk = Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/SEMultDist_{fdcomb}')
+                hMEmultk = Load(systFile, f'HMResults{iSystVar}/HMResults{iSystVar}/{fdcomb}/MEMultDist_{fdcomb}')
+
+            nbins = hMEmultk.ProjectionX().GetNbinsX()
+            hMEreweightk = TH1D("MErewdistr", "MErewdistr", nbins, hMEmultk.GetXaxis().GetXmin(), hMEmultk.GetXaxis().GetXmax())
+            for iBin in range(hMEmultk.ProjectionY().GetNbinsX() + 2): # Loop over underflow, all bins, and overflow
+                hSEbinmult = hSEmultk.ProjectionX(f'{comb}SEdistr', iBin, iBin)
+                hMEbinmult = hMEmultk.ProjectionX(f'{comb}MEdistr', iBin, iBin)
+                if(hMEbinmult.Integral() > 0):
+                    hMEreweightk.Add(hMEbinmult, hSEbinmult.Integral()/hMEbinmult.Integral())
+            hMErew[comb] = hMEreweightk
 
         # Sum pair and antipair
         for comb in combs:
-            hSE['p02_13'] = {}
-            hSE['p03_12'] = {}
-            hME['p02_13'] = {}
-            hME['p03_12'] = {}
-            hMErew['p02_13'] = {}
-            hMErew['p03_12'] = {}
+            hSE['p02_13'] = hSE['p02'] + hSE['p13']
+            hME['p02_13'] = hME['p02'] + hME['p13']
+            hMErew['p02_13'] = hMErew['p02'] + hMErew['p13']
 
-            for region in regions:
-                hSE['p02_13'][region] = hSE['p02'][region] + hSE['p13'][region]
-                hME['p02_13'][region] = hME['p02'][region] + hME['p13'][region]
-                hMErew['p02_13'][region] = hMErew['p02'][region] + hMErew['p13'][region]
-
-                hSE['p03_12'][region] = hSE['p03'][region] + hSE['p12'][region]
-                hME['p03_12'][region] = hME['p03'][region] + hME['p12'][region]
-                hMErew['p03_12'][region] = hMErew['p03'][region] + hMErew['p12'][region]
+            hSE['p03_12'] = hSE['p03'] + hSE['p12']
+            hME['p03_12'] = hME['p03'] + hME['p12']
+            hMErew['p03_12'] = hMErew['p03'] + hMErew['p12']
 
         # Compute the CF and write to file
         for comb in combs + ['p02_13', 'p03_12']:
-            for region in regions:
-                rebin = round(float(cfg['binwidth']) / (hSE[comb][region].GetBinWidth(1) * 1000))
-                hSE[comb][region].Rebin(rebin)
-                hME[comb][region].Rebin(rebin)
-                hMErew[comb][region].Rebin(rebin)
+            rebin = round(float(cfg['binwidth']) / (hSE[comb].GetBinWidth(1) * 1000))
+            hSE[comb].Rebin(rebin)
+            hME[comb].Rebin(rebin)
+            hMErew[comb].Rebin(rebin)
 
-                if cfg['norm'] is None:  # if not specified, normalize to the yields
-                    norm = hME[comb][region].GetEntries() / hSE[comb][region].GetEntries()
-                    normrew = hMErew[comb][region].GetEntries() / hSE[comb][region].GetEntries()
-                else:
-                    firstBin = hSE[comb][region].FindBin(cfg['norm'][0]*1.0001)
-                    lastBin = hSE[comb][region].FindBin(cfg['norm'][1]*0.9999)
-                    norm = hME[comb][region].Integral(firstBin, lastBin) / hSE[comb][region].Integral(firstBin, lastBin)
-                    normrew = hMErew[comb][region].Integral(firstBin, lastBin) / hSE[comb][region].Integral(firstBin, lastBin)
+            if cfg['norm'] is None:  # if not specified, normalize to the yields
+                norm = hME[comb].GetEntries() / hSE[comb].GetEntries()
+                normrew = hMErew[comb].GetEntries() / hSE[comb].GetEntries()
+            else:
+                firstBin = hSE[comb].FindBin(cfg['norm'][0]*1.0001)
+                lastBin = hSE[comb].FindBin(cfg['norm'][1]*0.9999)
+                norm = hME[comb].Integral(firstBin, lastBin) / hSE[comb].Integral(firstBin, lastBin)
+                normrew = hMErew[comb].Integral(firstBin, lastBin) / hSE[comb].Integral(firstBin, lastBin)
 
-                hSE[comb][region].Sumw2()
-                hME[comb][region].Sumw2() # Just to trigger the same draw option as for hSE
+            hSE[comb].Sumw2()
+            hME[comb].Sumw2() # Just to trigger the same draw option as for hSE
 
-                hCF = norm * hSE[comb][region] / hME[comb][region]
-                hCFrew = normrew * hSE[comb][region] / hMErew[comb][region]
+            hCF = norm * hSE[comb] / hME[comb]
+            hCFrew = normrew * hSE[comb] / hMErew[comb]
 
-                oFile.mkdir(f'{comb}/{region}/{iSystVar}')
-                oFile.cd(f'{comb}/{region}/{iSystVar}')
+            oFile.mkdir(f'{comb}/var{iSystVar}')
+            oFile.cd(f'{comb}/var{iSystVar}')
 
-                hSE[comb][region].SetName(f'hSE_{iSystVar}')
-                hSE[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
-                hSE[comb][region].Write()
+            hSE[comb].SetName(f'hSE_{iSystVar}')
+            hSE[comb].SetTitle(';#it{k}* (GeV/#it{c});Counts')
+            hSE[comb].Write()
 
-                hME[comb][region].SetName(f'hME_{iSystVar}')
-                hME[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
-                hME[comb][region].Write()
+            hME[comb].SetName(f'hME_{iSystVar}')
+            hME[comb].SetTitle(';#it{k}* (GeV/#it{c});Counts')
+            hME[comb].Write()
 
-                hMErew[comb][region].SetName(f'hMErew_{iSystVar}')
-                hMErew[comb][region].SetTitle(';#it{k}* (GeV/#it{c});Counts')
+            hMErew[comb].SetName(f'hMErew_{iSystVar}')
+            hMErew[comb].SetTitle(';#it{k}* (GeV/#it{c});Counts')
 
-                hCF.SetName(f'hCF_{iSystVar}')
-                hCF.SetTitle(';#it{k}* (GeV/#it{c});#it{C}(#it{k}*)')
-                hCF.Write()
+            hCF.SetName(f'hCF_{iSystVar}')
+            hCF.SetTitle(';#it{k}* (GeV/#it{c});#it{C}(#it{k}*)')
+            hCF.Write()
 
-                hCFrew.SetName(f'hCFrew_{iSystVar}')
-                hCFrew.SetTitle(';#it{k}* (GeV/#it{c});#it{C}(#it{k}*)')
-                hCFrew.Write()
+            hCFrew.SetName(f'hCFrew_{iSystVar}')
+            hCFrew.SetTitle(';#it{k}* (GeV/#it{c});#it{C}(#it{k}*)')
+            hCFrew.Write()
 
-                print(f'Finished systematic variation n° {iSystVar}')
+        print(f'Finished systematic variation {iSystVar}')
 
+oFile.cd()
+hFemtoPairs.Write()
 oFile.Close()
 print(f'output saved in {oFileName}')

--- a/ComputeSystematicsCF.py
+++ b/ComputeSystematicsCF.py
@@ -33,7 +33,7 @@ with open(args.cfg, "r") as stream:
 regions = ['CFsystvar']
 
 # Define the output file
-oFileBaseName = 'SystCFs'
+oFileBaseName = 'RawSystCF'
 if cfg['suffix'] != '' and cfg['suffix'] is not None:
     oFileBaseName += f'_{cfg["suffix"]}'
 oFileName = os.path.join(cfg['odir'], oFileBaseName + '.root')
@@ -46,15 +46,6 @@ except OSError:
 combs = ['p02', 'p03', 'p12', 'p13']
 for comb in combs:
     oFile.mkdir(comb)
-
-# list of histograms each containing the CF entries for
-# all variations for a specific bin 
-hCFBinEntries = []
-for iBin in range(cfg['systevalnbins']):
-    hCFBinEntries.append(TH1D(f"h{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV", 
-                              f"h{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV", 
-                              cfg['systhistobins'], cfg['systhistolowedge'], 
-                              cfg['systhistouppedge']))
 
 # Compute the correlation functions for all systematic variations
 hSE = {}
@@ -160,60 +151,7 @@ for iSystFile, systFileName in enumerate(cfg['infilessyst']):
                 hCFrew.SetTitle(';#it{k}* (GeV/#it{c});#it{C}(#it{k}*)')
                 hCFrew.Write()
 
-                for iBin in range(cfg['systevalnbins']):
-                    hCFBinEntries[iBin].Fill(hCFrew.GetBinContent(iBin+1))
-
                 print(f'Finished systematic variation n° {iSystVar}')
 
-#hCFselected = TH1D() Load(TFile(cfg['infileCF']), cfg['infileCFpath'])
-#
-#oFile.cd()
-#oFile.mkdir('binsfits')
-#hCFYields = TH1D("hCFYields", "hCFYields", cfg['systevalnbins'], 
-#                 cfg['systevalnbins'][0]*cfg['binwidth'], 
-#                 cfg['systevalnbins'][1]*cfg['binwidth'])
-#hCFmeans = TH1D("hCFmeans", "hCFmeans", cfg['systevalnbins'], 
-#                 cfg['systevalnbins'][0]*cfg['binwidth'], 
-#                 cfg['systevalnbins'][1]*cfg['binwidth'])
-#hSystUnc = TH1D("hSystUnc", "hSystUnc", cfg['systevalnbins'], 
-#                 cfg['systevalnbins'][0]*cfg['binwidth'], 
-#                 cfg['systevalnbins'][1]*cfg['binwidth'])
-#hRelSystUnc = TH1D("hRelSystUnc", "hRelSystUnc", cfg['systevalnbins'], 
-#                 cfg['systevalnbins'][0]*cfg['binwidth'], 
-#                 cfg['systevalnbins'][1]*cfg['binwidth'])
-#hRelStatUnc = TH1D("hRelStatUnc", "hRelStatUnc", cfg['systevalnbins'], 
-#                   cfg['systevalnbins'][0]*cfg['binwidth'], 
-#                   cfg['systevalnbins'][1]*cfg['binwidth'])
-#hRatioStatSystUnc = TH1D("hRatioStatSystUnc", "hRatioStatSystUnc", cfg['systevalnbins'], 
-#                         cfg['systevalnbins'][0]*cfg['binwidth'], 
-#                         cfg['systevalnbins'][1]*cfg['binwidth'])
-#hCFWithStatSystUnc = TH1D("hCFWithStatSystUnc", "hCFWithStatSystUnc", cfg['systevalnbins'], 
-#                          cfg['systevalnbins'][0]*cfg['binwidth'], 
-#                          cfg['systevalnbins'][1]*cfg['binwidth'])
-#for iBin, ihCFbin in enumerate(hCFBinEntries):
-#    oFile.cd('binsfits')
-#    ihCFbin.Fit("gaus")
-#    ihCFbin.Write(f"hCFbin{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV")
-#    gausFit = ihCFbin.GetListOfFunctions().FindObject("gaus")
-#    hCFYields.SetBinContent(iBin+1, gausFit.GetParameter(0))
-#    hCFMeans.SetBinContent(iBin+1, gausFit.GetParameter(1))
-#    hSystUnc.SetBinContent(iBin+1, gausFit.GetParameter(2))
-#    hRelSystUnc.SetBinContent(iBin+1, hSystUnc.GetBinContent(iBin+1)/hCFselected.GetBinContent(iBin+1))
-#    hRelStatUnc.SetBinContent(iBin+1, hCFselected.GetBinError(iBin+1)/hCFselected.GetBinContent(iBin+1))
-#    hRelStatUnc.SetBinContent(iBin+1, hCFselected.GetBinError(iBin+1)/hSystUnc.GetBinContent(iBin+1))
-#    hCFWithStatSystUnc.SetBinContent(iBin+1, hCFselected.GetBinContent(iBin+1))
-#    hCFWithStatSystUnc.SetBinError(iBin+1, np.sqrt(hCFselected.GetBinError(iBin+1)**2 + 
-#                                                   hSystUnc.GetBinContent(iBin+1)**2 ) )
-#    
-#oFile.mkdir('systunc')
-#oFile.cd('systunc')    
-#hCFYields.Write()
-#hCFMeans.Write()
-#hSystUnc.Write()
-#hRelSystUnc.Write()
-#hRelStatUnc.Write()
-#hRelStatUnc.Write()
-#hCFWithStatSystUnc.Write()
-#
 oFile.Close()
 print(f'output saved in {oFileName}')

--- a/SystematicsCFAnalysis.py
+++ b/SystematicsCFAnalysis.py
@@ -1,0 +1,124 @@
+'''
+Script to compute the systematic uncertainties on the CF
+bin values.
+The output file is SystUncCF_suffix.root
+
+Usage:
+python3 SystematicsCFAnalysis.py cfg.yml
+
+'''
+import os
+import argparse
+import yaml
+import math
+
+from ROOT import TFile, TF1, TH1D
+
+from fempy import logger as log
+from fempy.utils.io import Load, GetKeyNames
+
+parser = argparse.ArgumentParser()
+parser.add_argument('cfg', default='')
+parser.add_argument('--debug', default=False, action='store_true')
+args = parser.parse_args()
+
+if args.debug:
+    log.setLevel(1)
+
+# Load yaml file
+with open(args.cfg, "r") as stream:
+    try:
+        cfg = yaml.safe_load(stream)
+    except yaml.YAMLError as exc:
+        log.critical('Yaml configuration could not be loaded. Is it properly formatted?')
+
+# Define the output file
+oFileBaseName = 'SystUncCF'
+if cfg['suffix'] != '' and cfg['suffix'] is not None:
+    oFileBaseName += f'_{cfg["suffix"]}'
+oFileName = os.path.join(cfg['odir'], oFileBaseName + '.root')
+
+# Open the output file
+try:
+    oFile = TFile.Open(oFileName, 'recreate')
+except OSError:
+    log.critical('The output file %s is not writable', oFileName)
+    
+# Load the CF selected for the analysis
+inFileCFSelected = TFile(cfg['infileCFselected'])
+inFileCFSystVar = TFile(cfg['infileCFsystvar'])
+
+if 'combs' in cfg:
+    combs = cfg['combs']
+else:
+    combs = ['p02', 'p03', 'p12', 'p13', 'p02_13', 'p03_12']
+
+# Compute the correlation functions for all systematic variations
+for comb in combs:
+    print(f'Picking pair {comb}')
+    oFile.mkdir(comb)
+    oFile.mkdir(f'{comb}/binsfits')
+    oFile.mkdir(f'{comb}/unc')
+    oFile.cd(comb)
+
+    # list of histograms each containing the CF entries for
+    # all variations for a specific bin 
+    hCFBinEntries = []
+    for iBin in range(cfg['systevalnbins'][0], cfg['systevalnbins'][1]):
+        hCFBinEntries.append(TH1D(f"h{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV", 
+                                  f"h{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV", 
+                                  cfg['systhistobins'], cfg['systhistolowedge'], 
+                                  cfg['systhistouppedge']))
+    
+    for iSystVar in range(1, cfg['systnvariations']):
+        print(f'Picking syst variation number {iSystVar}')
+        hSystVar = Load(inFileCFSystVar, f'{comb}/CFsystvar/{iSystVar}/hCFrew_{iSystVar}')
+
+        for iBin in range(cfg['systevalnbins'][0], cfg['systevalnbins'][1]):
+            hCFBinEntries[iBin].Fill(hSystVar.GetBinContent(iBin+1))
+
+    #for iBin, ihCFbin in enumerate(hCFBinEntries):
+    #    oFile.cd(f'{comb}/binsfits')
+    #    ihCFbin.Write(f"hCFbin{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV")
+        
+    nBins = cfg['systevalnbins'][1] - cfg['systevalnbins'][0] 
+    lowEdgeHisto = cfg['systevalnbins'][0]*cfg['binwidth']
+    uppEdgeHisto = cfg['systevalnbins'][1]*cfg['binwidth']
+    hCFSelected = Load(inFileCFSelected, f'{comb}/sgn/hCFrew')
+    hCFYields = TH1D("hCFYields", "hCFYields", nBins, lowEdgeHisto, uppEdgeHisto)
+    hCFMeans = TH1D("hCFmeans", "hCFmeans", nBins, lowEdgeHisto, uppEdgeHisto)
+    hSystUnc = TH1D("hSystUnc", "hSystUnc", nBins, lowEdgeHisto, uppEdgeHisto)
+    hRelSystUnc = TH1D("hRelSystUnc", "hRelSystUnc", nBins, lowEdgeHisto, uppEdgeHisto)
+    hRelStatUnc = TH1D("hRelStatUnc", "hRelStatUnc", nBins, lowEdgeHisto, uppEdgeHisto)
+    hRatioStatSystUnc = TH1D("hRatioStatSystUnc", "hRatioStatSystUnc", nBins, lowEdgeHisto, uppEdgeHisto)
+    hCFWithStatSystUnc = TH1D("hCFWithStatSystUnc", "hCFWithStatSystUnc", nBins, lowEdgeHisto, uppEdgeHisto)
+    
+    print('Evaluating the single bins ...')
+    for iBin, ihCFbin in enumerate(hCFBinEntries):
+        oFile.cd(f'{comb}/binsfits')
+        gaus = TF1(f"gaus_{iBin}", "gaus", cfg['systhistolowedge'], cfg['systhistouppedge'])
+        gaus.SetParameter(1, hCFSelected.GetBinContent(iBin+1))
+        ihCFbin.Fit(gaus, "SMRL+0", "")
+        ihCFbin.Write(f"hCFbin{cfg['binwidth']*iBin+(cfg['binwidth']/2)}MeV")
+        hCFYields.SetBinContent(iBin+1, gaus.GetParameter(0))
+        hCFMeans.SetBinContent(iBin+1, gaus.GetParameter(1))
+        hSystUnc.SetBinContent(iBin+1, gaus.GetParameter(2))
+        hRelSystUnc.SetBinContent(iBin+1, hSystUnc.GetBinContent(iBin+1)/hCFSelected.GetBinContent(iBin+1))
+        hRelStatUnc.SetBinContent(iBin+1, hCFSelected.GetBinError(iBin+1)/hCFSelected.GetBinContent(iBin+1))
+        hRatioStatSystUnc.SetBinContent(iBin+1, hCFSelected.GetBinError(iBin+1)/hSystUnc.GetBinContent(iBin+1))
+        hCFWithStatSystUnc.SetBinContent(iBin+1, hCFSelected.GetBinContent(iBin+1))
+        hCFWithStatSystUnc.SetBinError(iBin+1, math.sqrt(hCFSelected.GetBinError(iBin+1)**2 + 
+                                                       hSystUnc.GetBinContent(iBin+1)**2 ) )
+    
+    print('Writing histos with error informations ...')
+    oFile.cd(f'{comb}/unc')
+    hCFYields.Write()
+    hCFMeans.Write()
+    hSystUnc.Write()
+    hRelSystUnc.Write()
+    hRelStatUnc.Write()
+    hRatioStatSystUnc.Write()
+    hCFWithStatSystUnc.Write()
+
+oFile.Close()
+print(f'output saved in {oFileName}')

--- a/cfgSystAnalysis.yml
+++ b/cfgSystAnalysis.yml
@@ -1,0 +1,20 @@
+# where to save the output
+odir: path/to/output/dir
+suffix: suffix
+
+infileCFselected: /path/to/CF/used/in/data/analysis.root
+binwidth: 4      # MeV/c
+norm: [0.7, 0.8] # yield normalization with null
+
+infilessyst: ['/path/to/AnalysisResults1.root',
+              '/path/to/AnalysisResults2.root',
+              '/path/to/AnalysisResults3.root']
+
+suffixessyst: [[var1_AnRes1.root, var2_AnRes1.root, var3_AnRes1.root], # each AnalysisResults can
+               [var1_AnRes2.root, var2_AnRes2.root, var3_AnRes2.root], # have a custom number
+               [var1_AnRes3.root, var2_AnRes3.root, var3_AnRes3.root]] # of variations
+
+systevalmaxbin: 150   # maximum kstar bin for systematics evaluation
+systhistobins: 50     # nbins for the histo of the kstar bin entry variations
+systhistointerval: 0.05 # range of the histo of the kstar bin entry variations,
+                        # computed from the value of the selected CF for the bin


### PR DESCRIPTION
The analysis of the systematic variations is performed via 2 scripts:

1) `ComputeSystematicsCF`: the CF for every systematic variations are computed and the pair statistics is checked
2) `SystematicsCFanalysis`: taking as input the CFs previously computed, each bin distribution is fitted to estimate the systematic uncertainty

A common config file is used for both scripts and only the script `SystematicsCFanalysis` has to be executed. This script will call `ComputeSystematicsCF` only if no file with the CFs is present in the output folder indicated in the yml config file.